### PR TITLE
Compute start_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
 
+## v2.0.2
+
+### Fixed
+
+- Optional start time, in order to avoid errors when applying module
+
+## v2.0.1
+
+## v2.0.0
+
 ## v1.0.0
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_automation_schedule" "schedule" {
   automation_account_name = var.automation_account_name
   frequency               = var.frequency
   interval                = var.interval
-  start_time              = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd(timestamp(), "15m"))
+  start_time              = var.start_time == "" ? null : var.start_time
   expiry_time             = var.expiry_time
   timezone                = var.timezone
   week_days               = var.week_days

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_automation_schedule" "schedule" {
   automation_account_name = var.automation_account_name
   frequency               = var.frequency
   interval                = var.interval
-  start_time              = var.start_time
+  start_time              = formatdate("YYYY-MM-DD'T'hh:mm:ss'Z'", timeadd(timestamp(), "15m"))
   expiry_time             = var.expiry_time
   timezone                = var.timezone
   week_days               = var.week_days

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable "frequency" {
 variable "start_time" {
   type        = string
   description = "(Optional) Start time of the schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created."
+  default = ""
 }
 
 variable "expiry_time" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "frequency" {
 variable "start_time" {
   type        = string
   description = "(Optional) Start time of the schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created."
-  default.    = ""
+  default     = ""
 }
 
 variable "expiry_time" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "frequency" {
 variable "start_time" {
   type        = string
   description = "(Optional) Start time of the schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created."
-  default = ""
+  default.    = ""
 }
 
 variable "expiry_time" {


### PR DESCRIPTION
Optional start time, in order to avoid the following error when applying the module:

```bash
Error: start_time is "2020-11-30 11:10:00 +0000 UTC" and should be at least "5m0s" in the future

  on main.tf line 1, in resource "azurerm_automation_schedule" "schedule":
   1: resource "azurerm_automation_schedule" "schedule" {
```